### PR TITLE
Limit the maximum size of a pooled log msg

### DIFF
--- a/logger/logger_writer.go
+++ b/logger/logger_writer.go
@@ -22,7 +22,8 @@ import (
 import "C"
 
 const (
-	NumMessages = 10 * 1024 // number of allowed log messages
+	NumMessages    = 10 * 1024 // number of allowed log messages
+	MaxFreeMsgSize = 8 * 1024  // maximum size of a free pooled msg
 )
 
 // container for a pending log message
@@ -196,7 +197,12 @@ func logWriter() {
 		} else {
 			writeCustomSocket(msg)
 		}
-		msg.Reset()
+
+		if msg.Cap() > MaxFreeMsgSize {
+			*msg = logMessage{}
+		} else {
+			msg.Reset()
+		}
 		freeMsg(msg)
 	}
 	if customSock != nil {


### PR DESCRIPTION
Free log messages are pooled in a channel. When logging calls are made, the
message buffers are grown to accomodate the call and, after the message
is sent to syslog, the message is re-pooled with the new size.

In cases with absurdly long logging messages, the logging pool can grow a lot,
to the point of exhausting the process memory.

To prevent this, I added a limit to the maximum size of a pooled message.